### PR TITLE
preprocessor switch for random seeding

### DIFF
--- a/_eSSP/lib/Random.c
+++ b/_eSSP/lib/Random.c
@@ -124,31 +124,18 @@ unsigned long long GenerateRandomNumber(void)
 |	The instruction returns in registers EDX:EAX the count of ticks from processor reset.
 |	Added in Pentium. Opcode: 0F 31.				*/
 
-long long GetRTSC( void )
-{
-	/*int tmp1 = 0;
-	int tmp2 = 0;
-
-	__asm
-	{
-		RDTSC;			//Clock cycles since CPU started
-		mov tmp1, eax;
-		mov tmp2, edx;
-	}
-
-	return ((long long)tmp1 * (long long)tmp2);*/
-	long long result;
-	asm ("RDTSC" : "=A" (result));
-	return result;
-
-}
-
 
 long long GetSeed( void )
 {
+#ifdef __arm__
 	struct timeval currentTime;
 	gettimeofday(&currentTime, NULL);
 	long microsecond_time = (currentTime.tv_sec * (int)1e6 + currentTime.tv_usec) % __LONG_MAX__;
 	long long seed = microsecond_time*getpid() % __LONG_LONG_MAX__;
 	return seed;
+#else
+	long long result;
+	asm ("RDTSC" : "=A" (result));
+	return result;
+#endif
 }

--- a/_eSSP/lib/Random.h
+++ b/_eSSP/lib/Random.h
@@ -17,7 +17,6 @@ unsigned char MillerRabin (long long n, long long trials);
 unsigned char IsItPrime (long long n, long long a);
 long long XpowYmodN(long long x, long long y, long long N);
 unsigned long long GenerateRandomNumber(void);
-long long GetRTSC( void ); //ARM-dependant
 long long GetSeed( void ); //NIX dependant
 
 


### PR DESCRIPTION
The problem was that you did not remove the asm part, and the compiler still had to compile it even though it was not used.
I added a preprocessing instruction based on the `__arm__` macro that uses the non asm-version for arm.
I also merged GetRTSC -> GetSeed so that there is only one method left, which I think is cleaner.