### PR TITLE
Allow compilation on a Mac

### DIFF
--- a/_eSSP/Makefile
+++ b/_eSSP/Makefile
@@ -1,5 +1,13 @@
 LIBS=-lstdc++ -lpthread
 
+UNAME := $(shell uname)
+
+ifeq ($(UNAME), Darwin)
+LINK = -Wl,-all_load,-install_name,libessp.so.1
+else
+LINK = -Wl,-soname,libessp.so.1
+endif
+
 .PHONY: clean
 
 libessp.so:
@@ -8,7 +16,7 @@ libessp.so:
 	$(CC) -c -fPIC -ggdb -g3 -o $@ $^
 
 libessp.so: init.o ssp_helpers.o linux.o lib/bin/libitlssp.a
-	$(CC) -shared -fPIC -ggdb -g3 -Wl,-soname,libessp.so.1 -o $@ $^
+	$(CC) -shared -fPIC -ggdb -g3 $(LINK) -o $@ $^
 
 lib/bin/libitlssp.a:
 	mkdir -p lib/bin/shared


### PR DESCRIPTION
Apple's binutils ld ships with the default of `-undefined,error` so it will error on link, as the `download_in_progress` symbol is stripped from the binary.
Also, it uses -install_name rather than -soname

I didn't change the name of the .so file. Might be a good idea to use cmake to support cross-platform compilation instead, but this gets things working for me.